### PR TITLE
Fix package url imports.

### DIFF
--- a/identification_arx.ipynb
+++ b/identification_arx.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Plots\")"
    ]
   },
   {

--- a/identification_impulse_response.ipynb
+++ b/identification_impulse_response.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Plots\")"
    ]
   },
   {

--- a/identification_statespace.ipynb
+++ b/identification_statespace.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Optim\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Optim\"); Pkg.add(\"Plots\")"
    ]
   },
   {


### PR DESCRIPTION
All github http imports were using a broken syntax. Changed them all to plain imports. An alternative would be to use the correct `Pkg.add(url="...")` syntax.